### PR TITLE
Add Flask API and product list component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Backend API
+
+The `backend` folder contains a small [Flask](https://flask.palletsprojects.com/) application that
+exposes product data from a MySQL database. Install dependencies and run the API with:
+
+```
+pip install -r backend/requirements.txt
+python backend/app.py
+```
+
+The React app fetches product information from `http://localhost:5000/api/products`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,38 @@
+from flask import Flask, jsonify
+import mysql.connector
+from mysql.connector import Error
+
+app = Flask(__name__)
+
+
+def get_connection():
+    """Create a database connection."""
+    return mysql.connector.connect(
+        host="localhost",
+        user="root",
+        password="password",
+        database="web_store",
+    )
+
+
+@app.route("/api/products")
+def list_products():
+    """Return all products."""
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+        cursor.execute("SELECT id, name, price, image FROM products")
+        products = cursor.fetchall()
+        return jsonify(products)
+    except Error as e:
+        return jsonify({"error": str(e)}), 500
+    finally:
+        try:
+            cursor.close()
+            conn.close()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+mysql-connector-python

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import LoginModal from './components/Auth/LoginModal';
 import RegisterModal from './components/Auth/RegisterModal';
 import DineInConfirmationModal from './components/Confirmation/DineInConfirmationModal';
 import TakeawayConfirmationModal from './components/Confirmation/TakeawayConfirmationModal';
+import ProductList from './components/ProductList/ProductList';
 
 function App() {
   const [showCart, setShowCart] = useState(false);
@@ -82,6 +83,8 @@ function App() {
         onLoginClick={() => setShowLogin(true)}
         onRegisterClick={() => setShowRegister(true)}
       />
+
+      <ProductList />
 
       {/* Layout hiển thị tương ứng */}
       {showCart && <Cart 

--- a/src/components/ProductList/ProductList.js
+++ b/src/components/ProductList/ProductList.js
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+
+function ProductList() {
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:5000/api/products')
+      .then((res) => res.json())
+      .then((data) => setProducts(data))
+      .catch(() => setProducts([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Menu</h2>
+      <ul>
+        {products.map((p) => (
+          <li key={p.id}>
+            <img src={p.image} alt={p.name} width="50" />
+            <span>{p.name} - {p.price} VND</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default ProductList;


### PR DESCRIPTION
## Summary
- add Flask backend with `/api/products` for MySQL product data
- create React `ProductList` component to fetch and display products
- document backend setup and integrate product list into main app

## Testing
- `python -m py_compile backend/app.py`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6895fd6426a0832ea29af1d136305358